### PR TITLE
fix: Add parentheses in disk access time formula

### DIFF
--- a/12-Discos.html
+++ b/12-Discos.html
@@ -214,7 +214,7 @@
 						</li>
 						<br>
 						<p class="center">
-							<strong>T_acceso</strong> = n * T_búsqueda + T_latencia + T_transferencia.
+							<strong>T_acceso</strong> = n * ( T_búsqueda + T_latencia + T_transferencia ).
 						</p>
 					</ul>
 				</section>


### PR DESCRIPTION
This pull request addresses an issue in the disk access time formula presented in the Operating Systems course slides. Previously, the formula lacked necessary parentheses, which could lead to confusion and incorrect calculations. This update adds the missing parentheses to ensure clarity and accuracy in the formula's interpretation. This change aims to enhance the educational material and assist students in understanding disk access time calculations correctly.