### PR TITLE
correct grammatical errors and typos in HTML files

### DIFF
--- a/01-Introduccion.html
+++ b/01-Introduccion.html
@@ -160,7 +160,7 @@
 				<section id="arquitectura-von-neuman-2">
 					<h2>Arquitectura Von Neuman</h2>
 					<div class="half left">
-						<p class="text-left">Esta compuesta por:</p>
+						<p class="text-left">Está compuesta por:</p>
 						<ul>
 							<li>La unidad aritmético-lógica o ALU.</li>
 							<li>La unidad de control.</li>
@@ -257,7 +257,7 @@
 				</section>
 				<section id="lista-de-so">
 					<h2>Algunos sistemas operativos</h2>
-					<p> Entre los sistemas operativos mas conocidos tenemos: </p>
+					<p> Entre los sistemas operativos más conocidos tenemos: </p>
 					<ul>
 						<li>Windows, Windows 10 Mobile (Microsoft)</li>
 						<li>Linux (código libre)</li>
@@ -359,7 +359,7 @@
 					</div>
 					<ul class="nomargin">
 						
-						<li>Se usaban para cálculos matemáticos, calculo de tablas de cosenos y seno, entre otros.</li>
+						<li>Se usaban para cálculos matemáticos, cálculo de tablas de cosenos y seno, entre otros.</li>
 					</ul>
 				</section>
 				<section id="historia-so-3">
@@ -432,7 +432,7 @@
 						<li>
 							El sistema operativo carga las aplicaciones a ejecutar desde el disco 
 							(<strong><em>Spooling</em></strong>), 
-							permitiendo utilizar el CPU de manera mas óptima.
+							permitiendo utilizar el CPU de manera más óptima.
 						</li>
 					</ul>
 					<div class="third right">
@@ -448,7 +448,7 @@
 					<div  class="half left">
 						<ul>
 							<li>
-								Sistemas mas amigables con el usuario, maneja las operaciones y control 
+								Sistemas más amigables con el usuario, maneja las operaciones y control
 								de usuarios localmente.
 							</li>
 							<li>
@@ -477,7 +477,7 @@
 					<div class="half left">
 						<ul>
 							<li>
-								Sistemas enfocados en una interfaz mas sencilla y diseñada para
+								Sistemas enfocados en una interfaz más sencilla y diseñada para
 							 	funcionar en pantallas muy pequeñas.
 							 </li>
 							<li>
@@ -533,7 +533,7 @@
 									variables, la siguiente instrucción a ejecutar, etc. (El estado 
 									de la aplicación)
 								</li>
-								<li>Otra información requerida por el S.O. para la planficación.</li>
+								<li>Otra información requerida por el S.O. para la planificación.</li>
 							</ul>
 						</li>
 					</ul>
@@ -551,7 +551,7 @@
 						<li>
 							Un proceso tiene un <strong>UID</strong> (usuario quien lo ejecutó) 
 							y un <strong>PID</strong> (número del proceso).</li>
-						<li>Un proceso puede crear uno o mas procesos hijos.</li>
+						<li>Un proceso puede crear uno o más procesos hijos.</li>
 					</ul>
 				</section>
 				<section id="archivos">
@@ -727,7 +727,7 @@
 				<section id="tipo-so-servicios" class="fragment">
 					<h2>Tipos de S.O. por servicios</h2>
 					<p>
-						Es la clasificación mas conocida desde el punto de vista del usuario final, para 
+						Es la clasificación más conocida desde el punto de vista del usuario final, para
 						hacerla se toman en cuenta los siguientes criterios: 
 					</p>
 					<ul>
@@ -792,7 +792,7 @@
 						<li>
 							<h3>S.O. de red</h3>
 							Se acceden a través de conexiones remotas, posee sus archivos
-							compartido por la red, se ejecutan comandos remotos, etc.
+							compartidos por la red, se ejecutan comandos remotos, etc.
 						</li>
 						<li>
 							<h3>S.O. distribuidos</h3>

--- a/02-Procesos.html
+++ b/02-Procesos.html
@@ -302,7 +302,7 @@
 							realizando sus operaciones.
 						 </li>
 						<li>
-							<strong>Espera/Bloqueado: </strong> no está en el CPU y esta
+							<strong>Espera/Bloqueado: </strong> no está en el CPU y está
 							en espera de un evento (operación con un dispositivo de E/S
 							o por una señal).
 						</li>

--- a/03-Hilos.html
+++ b/03-Hilos.html
@@ -73,7 +73,7 @@
 						</li>
 						<li>
 							Es diferente un proceso hijo (se ejecuta en
-							espacio de direcciones separados) a un hilo (se
+							espacio de direcciones separadas) a un hilo (se
 							ejecuta en el mismo espacio de direcciones)
 						</li>
 					</ul>
@@ -135,11 +135,11 @@
 							esté bloqueado.
 							(generalmente por acceso a dispositivos de E/S)
 						</li>
-						<li>Son mas rápidas de crear, hasta 10 veces mas que un proceso.</li>
-						<li>Es mas económico realizar el cambio de contexto.</li>
+						<li>Son más rápidas de crear, hasta 10 veces más que un proceso.</li>
+						<li>Es más económico realizar el cambio de contexto.</li>
 						<li>
-							Mas rápido de eliminar pues solo es necesario
-							vaciar su pila y registros,en un proceso toca eliminar todo el PCB.
+							Más rápido de eliminar pues solo es necesario
+							vaciar su pila y registros, en un proceso toca eliminar todo el PCB.
 						</li>
 					</ul>
 				</section>
@@ -232,7 +232,7 @@
 					<h3>POSIX</h3>
 					<ul>
 						<li>Estándar definido por la IEEE conocido como 1003.1c</li>
-						<li>Define mas de 60 llamadas a funciones para gestionar hilos.</li>
+						<li>Define más de 60 llamadas a funciones para gestionar hilos.</li>
 						<li>Aceptado por la mayoría de sistemas UNIX.</li>
 					</ul>
 				</section>

--- a/04-GestionProcesos.html
+++ b/04-GestionProcesos.html
@@ -128,7 +128,7 @@
 					<aside class="notes">
 						La ejecución de un proceso consiste en una alternancia entre,
 						ráfagas de CPU y ráfagas de E/S. Un proceso limitado por E/S
-						es aquél mayor tiempo accediendo a la E/S que usando el CPU 
+						es aquél mayor tiempo accediendo a la E/S que usando el CPU
 						(ráfagas de CPU cortas), un proceso limitado por CPU pasa 
 						más tiempo computando que accediendo a E/S (ráfagas de CPU largas).
 					</aside>
@@ -220,7 +220,7 @@
 					<h3>Procesamiento por lotes</h3>
 					<ul>
 						<li>Primero en entrar, primero en ser atendido (FCFS)</li>
-						<li>Trabajo mas corto primero (SJF)</li>
+						<li>Trabajo más corto primero (SJF)</li>
 						<li>Menor tiempo restante a continuación (SRTN)</li>
 					</ul>
 				</section>
@@ -408,7 +408,7 @@
 						Asigna un espacio de tiempo a cada proceso (<strong>cuanto o quantum</strong>)
 						para ejecutarse, si el proceso: termina, acaba el cuanto, se bloquea por acceso
 						a E/S. El S.O. hace un cambio de contexto y lo coloca (si aún debe seguir 
-						ejecútandose) al final de la cola.
+						ejecutándose) al final de la cola.
 					</p>
 					<ul >
 						<li>El cuanto o quantum suele estar entre los 10ms y 100ms.</li>
@@ -494,7 +494,7 @@
 					<h3>Por prioridades</h3>
 					<p>
 						Cada proceso tiene asociado una prioridad, entonces al momento de quedar la CPU
-						libre, se le asigna el proceso con la prioridad mas alta. Sin embargo, hay que
+						libre, se le asigna el proceso con la prioridad más alta. Sin embargo, hay que
 						tener cuidado, pues los procesos con baja prioridad pueden no ser ejecutados debido
 						a la llegada de procesos con prioridad superior, esto se resuelve aplicando
 						la técnica de <strong>envejecimiento.</strong>
@@ -575,7 +575,7 @@
 						<ul>
 							<li>
 								Cada proceso es clasificado en grupos, por ejemplo: de primer o segundo 
-								plano,de usuario o del sistema, de usuarios locales o remotos,
+								plano, de usuario o del sistema, de usuarios locales o remotos,
 								tamaño de memoria, prioridad, entre otros.
 							</li>
 							<li>
@@ -583,7 +583,7 @@
 								una para agrupación realizada. 
 							</li>
 							<li>
-								Cada una de las cola posee su propio algoritmo de planificación 
+								Cada una de las colas posee su propio algoritmo de planificación
 								para cada proceso dentro de ella.
 							</li>
 							<li>
@@ -738,7 +738,7 @@
 							<strong>Desventajas:</strong> Es equitativo para el 
 							usuario pero no para el CPU o los procesos. Un usuario puede
 							tener mucho CPU asignado y no lo usará nunca.
-							Un usuario puede necesitar mas CPU del asignado
+							Un usuario puede necesitar más CPU del asignado
 							y tampoco lo podrá conseguir. 
 						</li>
 					</ul>
@@ -786,12 +786,12 @@
 							que todos trabajen a un ritmo similar.
 						</li>
 						<li>
-							<strong>Multiprocesamiento asimetrico:</strong> un núcleo se suele 
+							<strong>Multiprocesamiento asimétrico:</strong> un núcleo se suele
 							encargar de realizar la planificación, procesamiento
 							de las E/S y actividades del sistema operativo.
 						</li>
 						<li>
-							<strong>Multiprocesamiento simetrico (SMP):</strong> cada procesador 
+							<strong>Multiprocesamiento simétrico (SMP):</strong> cada procesador
 							se autoplanifica: existe una cola de procesos preparados en común
 							o cada uno tiene su propia cola, existe seguridad para no tomar 
 							el mismo proceso al mismo tiempo.
@@ -865,7 +865,7 @@
 					</p>
 					<aside class="notes">
 						Mac OS utiliza tiempo real porque está diseñado para computadoras
-						de escritorio y necesita responder lo mas rápido las peticiones
+						de escritorio y necesita responder lo más rápido las peticiones
 						de entrada de usuarios
 					</aside>
 				</section>
@@ -881,7 +881,7 @@
 						regresa a la cola, ésta se coloca en una posición en base al tiempo que duró en el procesador.
 					</p>
 					<aside class="notes">
-						Tomar en cuenta que si salio un proceso por espera de E/S entonces
+						Tomar en cuenta que si salió un proceso por espera de E/S entonces
 						duró poco tiempo en el CPU.
 					</aside>
 				</section>

--- a/05-SincronizacionProcesos.html
+++ b/05-SincronizacionProcesos.html
@@ -109,8 +109,8 @@
 		                Fenómeno producido cuando varios procesos
 		                <strong> compiten por el acceso a uno o varios recursos </strong>
 		                produciendo el bloqueo en la ejecución. Ocasiona
-		                el cuelge del S.O. Para evitarlo se debe garantizar el acceso
-		                seguro a recursos compartidos,<strong>coordinando y sincronizando los
+		                el cuelgue del S.O. Para evitarlo se debe garantizar el acceso
+		                seguro a recursos compartidos,<strong> coordinando y sincronizando los
 		                procesos.</strong>
 		            </p>
 		            <div class="center">
@@ -143,8 +143,8 @@
 		                    u orden de ejecución de los procesos.
 		                </li>
 		                <li class="fragment">
-		                    <strong>Ningún proceso</strong> ejecutandose
-		                    fuera de su sección crítica <strong>puede bloquear otro procesos</strong>.
+		                    <strong>Ningún proceso</strong> ejecutándose
+		                    fuera de su sección crítica <strong>puede bloquear otros procesos</strong>.
 		                </li>
 		                <li class="fragment">
 		                    <strong>Ningún proceso deberá tener que esperar
@@ -155,9 +155,9 @@
 	            <section id="exclusion-mutua">
 	                <h2>Exclusión Mutua</h2>
 	                <p>
-	                    Es el método mas común para evitar el uso simultáneo
+	                    Es el método más común para evitar el uso simultáneo
 	                    de los recursos del sistema como variables globales y dispositivos de E/S, por
-	                    dos (2) o mas procesos del sistema.
+	                    dos (2) o más procesos del sistema.
 	                </p>
 		        </section>
 		        <section id="exclusion-mutua-2">
@@ -187,7 +187,7 @@
 		            <h2>Exclusión Mutua<br> con espera ocupada</h2>
 		            <h3>Desactivación de Interrupciones (hardware)</h3>
 		            <p>
-		                Es el método mas simple, consiste en desactivar todas las interrupciones
+		                Es el método más simple, consiste en desactivar todas las interrupciones
 		                de hardware antes de entrar a la sección crítica. Sin embargo,
 		                en la práctica no es recomendable porque si el proceso falla en
 		                su sector crítico, el sistema operativo no puede recuperarse y se
@@ -261,7 +261,7 @@
 		                 Conocido también como la primera versión del
 		                 algoritmo de Dekker, obliga a cada proceso tener un turno
 		                 y <strong>existe un cambio de turno cada vez que un proceso
-		                 sale de la sección critica.</strong>
+		                 sale de la sección crítica.</strong>
 		             </p>
 		             <ul>
 		                <li class="fragment">
@@ -269,7 +269,7 @@
 		                    en una sección crítica.
 		                </li>
 		                <li class="fragment">
-		                    Si un proceso es mas lento que el otro, bloquea al otro
+		                    Si un proceso es más lento que el otro, bloquea al otro
 		                    por mucho tiempo. <strong>Viola la regla 3:</strong>
 		                    ningún proceso debe bloquear a otro fuera de su sección crítica.
 		                </li>
@@ -401,7 +401,7 @@ void salirSC(int proceso) {
 	                <h3>Problema del Productor - Consumidor</h3>
 	                <ul>
 	                    <li>Es un problema donde se puede aplicar este algoritmo.</li>
-	                    <li>Dos procesos comparter un buffer de tamaño fijo.</li>
+	                    <li>Dos procesos comparten un buffer de tamaño fijo.</li>
 	                    <li>Un proceso es el productor y añade información al buffer.</li>
 	                    <li>Otro es el consumidor y lee (o modifica) la información del buffer.</li>
 	                </ul>
@@ -415,7 +415,7 @@ void salirSC(int proceso) {
 		                    algún elemento)
 		                </li>
 		                <li>
-		                    El problema del consumidor es cuando va consumir un elemento del buffer
+		                    El problema del consumidor es cuando va a consumir un elemento del buffer
 		                    pero está vacío. (Se va a dormir y despierta cuando exista
 		                    un elemento)
 		                </li>
@@ -482,12 +482,12 @@ void salirSC(int proceso) {
 		                    y <strong>signal()</strong>.
 		                </li>
 		                <li class="fragment">
-		                    Simboliza el numero de <em>wakeups</em>
+		                    Simboliza el número de <em>wakeups</em>
 		                    pendientes, 0 indica que no hay alguno por despertar.
 		                </li>
 		                <li class="fragment">
 		                    <strong>wait() - DOWN</strong>
-		                    verifica si el valor del semaforo es mayor a cero.
+		                    verifica si el valor del semáforo es mayor a cero.
 		                    Si es así, lo decrementa y continúa sus
 		                    operaciones; en caso contrario se va a dormir y espera
 		                    para continuar.
@@ -501,7 +501,7 @@ void salirSC(int proceso) {
 		                <li>
 		                    <strong>signal() - UP</strong>
 		                    incrementa el valor del semáforo. Si existe uno o
-		                    mas procesos dormidos y no pueden completar una operación
+		                    más procesos dormidos y no pueden completar una operación
 		                    <em>wait()</em>, el semáforo elige uno al azar
 		                    y le permite completar <em>wait()</em>.
 		                </li>
@@ -528,7 +528,7 @@ void salirSC(int proceso) {
 		            </ol>
 		        </section>
 		        <section id="productor-consumidor-semaforos-2">
-		            <h2>Productor - Consumidor<br> con Semaforos</h2>
+		            <h2>Productor - Consumidor<br> con Semáforos</h2>
 		            <div class="center">
 		                <pre>
 		                	<code class="cpp">#define N 100
@@ -578,7 +578,7 @@ semaforo mutex = 1, empty = N, full = 0;
 			            </li>
 			            <li>
 			                Se encuentra en un nivel superior de los semáforos, ya que al usar
-			                estos últimos, si no estan programados correctamente pueden provocar
+			                estos últimos, si no están programados correctamente pueden provocar
 			                <strong>bloqueos mutuos.</strong>
 			            </li>
 		            </ul>
@@ -586,8 +586,8 @@ semaforo mutex = 1, empty = N, full = 0;
 	           <section id="bloqueos-mutuos">
                     <h2>Bloqueos mutuos (deadlocks)</h2>
 	                <div class="third left">
-                        Ocurre cuando 2 o mas procesos esperan indefinidamente un evento que sólo
-                        puede ocurrir por uno de los otros procesos que estan esperando.
+                        Ocurre cuando 2 o más procesos esperan indefinidamente un evento que sólo
+                        puede ocurrir por uno de los otros procesos que están esperando.
 	                </div>
 	                <div class="twothird left">
 	                    <a href="img/class5/deadlock.jpg" data-lightbox="deadlock">

--- a/06-Interbloqueo.html
+++ b/06-Interbloqueo.html
@@ -165,7 +165,7 @@
 						<li>El proceso es representado por un <strong>círculo</strong>.</li>
 						<li>El recurso se representa con un <strong>cuadrado</strong>.</li>
 						<li>
-							En caso de existir mas de una instacia de un recurso, dentro
+							En caso de existir mas de una instancia de un recurso, dentro
 							del cuadrado se observarán cada una de ellas.
 						</li>
 						<li>
@@ -247,8 +247,8 @@
 						</li>
 						<li><strong>Retención y espera:</strong>
 							un proceso está reteniendo
-							un recurso y espera para por otro recurso adicional pero
-							retenido por otro proceso.
+							un recurso y espera por otro recurso adicional pero
+							está retenido por otro proceso.
 						</li>
 					</ul>
 				</section>
@@ -336,7 +336,7 @@
 						<li>
 							Un proceso <strong>sólo puede solicitar recursos cuando
 							no tiene ninguno asignado</strong>. Pero puede ocurrir
-							que  se libera un recurso y mas tarde se debe volver
+							que  se libera un recurso y más tarde se debe volver
 							a pedirlo para solicitar otros recursos.
 						</li>
 					</ul>
@@ -374,7 +374,7 @@
 					<h3>Prevención del Interbloqueo - Espera circular</h3>
 					<p>
 						A cada recurso se le asigna un orden, y el proceso solo puede solicitar
-						recursos con un orden superior al recurso actual. Ademas debe liberar
+						recursos con un orden superior al recurso actual. Además debe liberar
 						el recurso retenido para obtener el solicitado.
 					</p>
 					<p>
@@ -452,7 +452,7 @@
 						<li>
 							Dada una secuencia de procesos <strong>P = {P1, P2, ..., Pn}</strong>,
 							se considera como <strong>estado seguro</strong>, si los recursos
-							que pide Pi, en el peor de los casos se pueden antender
+							que pide Pi, en el peor de los casos se pueden atender
 							con los recursos disponibles más los recursos poseídos por todos
 							los procesos <strong>Pj, j %lt; i</strong> (procesos anteriores).
 						</li>
@@ -674,7 +674,7 @@
 				</section>
 				<section id="algoritmo-avestruz">
 					<h2>Estrategias para<br>enfrentar los bloqueos</h2>
-					<h3>Ignorar todo el problema<br> (Algoritmo del Avestruz</h3>
+					<h3>Ignorar todo el problema<br> (Algoritmo del Avestruz)</h3>
 					<ul>
 						<li>
 							Es el algoritmo mas simple: Meta su cabeza en la
@@ -710,8 +710,8 @@
 					<h3>Detección y recuperación de Interbloqueo</h3>
 					<h4>Detección</h4>
 					<ul>
-						<li>Una sola instacia de recurso para cada tipo.</li>
-						<li>Varias instacias de cada tipo de recursos.</li>
+						<li>Una sola instancia de recurso para cada tipo.</li>
+						<li>Varias instancias de cada tipo de recursos.</li>
 					</ul>
 					<h4>Recuperación</h4>
 					<ul>

--- a/07-GestionMemoria.html
+++ b/07-GestionMemoria.html
@@ -129,7 +129,7 @@
 						</li>
 						<li>
 							Decodifica la instrucción mediante la unidad de control y
-							coordina los demas componentes para ejecutarla.
+							coordina los demás componentes para ejecutarla.
 						</li>
 						<li>Se ejecuta la instrucción. (Cuando se realizan ciclos se
 							modifica el contador del programa para repetir
@@ -142,11 +142,11 @@
 					<div class="left half">
 						<ul>
 							<li>
-								Todos los CPUs estan conectados por el
+								Todos los CPUs están conectados por el
 								mismo canal al puente norte.
 							</li>
 							<li>
-								Todos los dispositivos de E/S estan conectados
+								Todos los dispositivos de E/S están conectados
 								al puente sur.
 							</li>
 						</ul>
@@ -371,7 +371,7 @@
 						 <li>
 						 	A veces, los procesos pueden ser intercambiados temporalmente,
 						 	sacándolos de la memoria y almacenándolos en <strong>
-						 	un almacén de respaldo</strong>. Y luego vicerversa.
+						 	un almacén de respaldo</strong>. Y luego viceversa.
 						 </li>
 						 <li>
 						 	El <strong> un almacén de respaldo</strong> o <strong>
@@ -390,7 +390,7 @@
 					<ul>
 						 <li>
 						 	El algoritmo para el intercambio, se llama <strong>Roll out,
-						 	roll in</strong> y es una variante del algoritmos de
+						 	roll in</strong> y es una variante de los algoritmos de
 						 	planificación basados en prioridad; un proceso de baja
 						 	prioridad se retira de memoria para cargar y ejecutar
 						 	otro con mayor prioridad.
@@ -511,7 +511,7 @@
 						</li>
 						<li>
 							El S.O. mantiene una tabla de particiones para conocer
-							cuáles estan libres u ocupadas.
+							cuáles están libres u ocupadas.
 						</li>
 					</ul>
 					<aside class="notes">
@@ -672,7 +672,7 @@
 					</ul>
 					<aside class="notes">
 						<p>
-							Para el mejor ajuste,se
+							Para el mejor ajuste, se
 						debe buscar en toda la lista de huecos
 						(salvo si está ordenada por tamaño).
 						</p>
@@ -715,7 +715,7 @@
 				</section>
 
 				<section id="evitar-fragmentacion">
-					<h2>¿Cómo evitar la fragmentación</h2>
+					<h2>¿Cómo evitar la fragmentación?</h2>
 					<p>Existen 2 maneras de evitarla:</p>
 					<ul>
 						<li>
@@ -730,7 +730,7 @@
 					</ul>
 					<aside class="notes">
 						El kernel prefiere el segundo método porque cuando se hace operaciones
-						DMA no se respeta el orden de los circuitos, se dañá la tabla de páginas
+						DMA no se respeta el orden de los circuitos, se daña la tabla de páginas
 						y se debe actualizar, conviene tener muchos bloques para mejorar la
 						caché.
 					</aside>

--- a/08-PaginacionSegmentacion.html
+++ b/08-PaginacionSegmentacion.html
@@ -394,8 +394,8 @@
 				<div class="text-left">
 					<ul>
 						<li>Tasa de aciertos: <strong>80%</strong>.</li>
-						<li>Tiempo accesso a TLB: <strong>20 ns</strong>.</li>
-						<li>Tiempo accesso a memoria: <strong>100 ns</strong>.</li>
+						<li>Tiempo acceso a TLB: <strong>20 ns</strong>.</li>
+						<li>Tiempo acceso a memoria: <strong>100 ns</strong>.</li>
 
 					</ul>
 				</div>
@@ -472,7 +472,7 @@
 							Si tablas de página ocupa mucho espacio,
 							éstas se someten a una paginación, creando una organización
 							páginada de múltiples niveles. Por ejemplo,
-							<strong>la páginacion en dos niveles</strong>.
+							<strong>la paginación en dos niveles</strong>.
 						</li>
 						<li>
 							Las direcciones lógicas ahora poseen la siguiente estructura:

--- a/09-MemoriaVirtual.html
+++ b/09-MemoriaVirtual.html
@@ -100,7 +100,7 @@
 					<aside class="notes">
 						<ul class="clear">
 							<li>
-								Permite al sistema operativo ejecutar mas procesos
+								Permite al sistema operativo ejecutar más procesos
 								al mismo tiempo. Pues cada programa podría
 								ocupar menos espacio en la memoria física.
 							</li>
@@ -130,11 +130,11 @@
 						<li>
 							Se selecciona una página en memoria (usando un algoritmo
 							de sustitución de páginas), si esta tuvo modificaciones
-							se escribe en el area de intercambio y se procesde a leer la
+							se escribe en el área de intercambio y se procede a leer la
 							página solicitada para realizar el intercambio de páginas.
 						</li>
 						<li>
-							En caso de no existir la página en el area de intercambio
+							En caso de no existir la página en el área de intercambio
 							se carga desde el disco duro.
 						</li>
 					</ul>
@@ -147,7 +147,7 @@
 							<li>Trampa.</li>
 							<li>La página está en el almacen de respaldo.</li>
 							<li>Carga la página que falta.</li>
-							<li>Reestablece la Tabla de páginas.</li>
+							<li>Restablece la Tabla de páginas.</li>
 							<li>Reinicia la instrucción.</li>
 						</ol>
 					</div>
@@ -162,7 +162,7 @@
 
 					<aside class="notes">
 						El S.O. no carga las páginas a memoria apenas se le solicitan,
-						siempre espera hasta el último momento (fallo de pagina) para hacerlo
+						siempre espera hasta el último momento (fallo de página) para hacerlo
 					</aside>
 				</section>
 
@@ -201,7 +201,7 @@
 							cargadas las páginas, al momento de
 							<strong>no existir marcos de página
 							libres</strong>, retira de memoria la
-							página mas antigua
+							página más antigua
 							<em>(la que llegó primero a memoria)</em>.
 						</li>
 						<li>
@@ -211,7 +211,7 @@
 						<li>
 							Un <strong>problema</strong> de este algoritmo
 							es que se puede quitar de memoria una página
-							muy utilizada solo porque es la mas antigua en
+							muy utilizada solo porque es la más antigua en
 							memoria.
 						</li>
 					</ul>
@@ -221,7 +221,7 @@
 					<h3>Segunda oportunidad</h3>
 					<ul>
 						<li>
-							Es una módificacion del algoritmo anterior,
+							Es una modificación del algoritmo anterior,
 							literalmente le da una segunda oportunidad
 							a las páginas antes de moverlas de la
 							memoria principal.
@@ -233,7 +233,7 @@
 						<li>
 							Sigue el mismo principio de FIFO, pero antes
 							de sacar la página de memoria comprueba el bit
-							de refencia, si esta en <strong>001</strong>
+							de refencia, si está en <strong>001</strong>
 							(fijado) se cambia a <strong>099</strong> como
 							si estuviese entrando de nuevo (dando una segunda
 							oportunidad), en caso contrario, lo libera.
@@ -265,7 +265,7 @@
 						</li>
 						<li>
 							Con la combinación de estos bits se crean
-							las siguientes clase:
+							las siguientes clases:
 							<ul>
 								<li><strong>Clase 0:</strong> No solicitada, no modificada.</li>
 								<li><strong>Clase 1:</strong> No solicitada, modificada.</li>
@@ -287,8 +287,8 @@
 						</li>
 						<li>
 							El algoritmo desaloja, una página al azar de
-							la clase mas inferior. Da prioridad a las páginas
-							pocos referenciadas en lugar de las solicitadas
+							la clase más inferior. Da prioridad a las páginas
+							poco referenciadas en lugar de las solicitadas
 							frecuentemente con modificaciones.
 						</li>
 					</ul>
@@ -360,7 +360,7 @@
 					<h2>Sobrepaginación</h2>
 					<ul>
 						<li>
-							Sucede cuando un proceso invierte mas tiempo
+							Sucede cuando un proceso invierte más tiempo
 							en implementando mecanismos de paginación
 							que en su propia ejecución.
 						</li>
@@ -394,7 +394,7 @@
 					<ul>
 						<li>
 							Mientras se accede al archivo físicamente en el
-							disco, se provocan fallos de pagina, lo que
+							disco, se provocan fallos de página, lo que
 							ocasiona que se vaya cargando el archivo del
 							disco a marcos de página en la memoria
 							principal.

--- a/10-Archivos.html
+++ b/10-Archivos.html
@@ -149,7 +149,7 @@
 						</li>
 						<li>
 							No es posible escribir datos en un
-							almacenamiento secundario si no esta dentro
+							almacenamiento secundario si no está dentro
 							de un archivo. 
 						</li>
 					</ul>
@@ -275,7 +275,7 @@
 						</li>
 					</ul>
 					<p class="note">
-						<strong>Nota:</strong> Los puntero de lectura y escritura 
+						<strong>Nota:</strong> Los punteros de lectura y escritura
 						son únicos para cada proceso.
 					</p>
 					<aside class="notes">

--- a/11-SistemaArchivos.html
+++ b/11-SistemaArchivos.html
@@ -82,7 +82,7 @@
 						</li>
 						<li>Cada Sistema Operativo suele soportar sus propios sistemas de archivos.</li>
 						<li>
-							Algunos estan diseñados para velocidad, otro para grandes archivos, para pequeños, 
+							Algunos están diseñados para velocidad, otro para grandes archivos, para pequeños,
 							para base de datos, lectura rápida, etc.
 						</li>
 					</ul>
@@ -104,7 +104,7 @@
 						</li>
 					</ul>
 					<aside class="notes">
-						Los discos se pueden dividir en una o mas
+						Los discos se pueden dividir en una o más
 						particiones con sistemas de archivos
 						independientes en cada partición
 					</aside>
@@ -243,7 +243,7 @@
 						Se pueden utilizar todos los bloques del disco. No pierde
 						espacio por fragmentación.
 
-						Es mucho mas lento puesto que debe recorrer y buscar
+						Es mucho más lento puesto que debe recorrer y buscar
 						cada bloque del archivo en operaciones separadas.
 					</aside>
 				</section>
@@ -285,7 +285,7 @@
 						</li>
 						<li>
 							Esta lista solo necesita estar en memoria cuando el
-							archivo esta abierto.
+							archivo está abierto.
 						</li>
 						<li>
 							Si un nodo-i ocupa <em>n</em> bytes y puede haber 
@@ -333,7 +333,7 @@
 						</li>
 						<li>
 							Una transacción se compromete cuando 
-							está escrita en la bitácora, pero no esta
+							está escrita en la bitácora, pero no está
 							actualizada en el S.A.
 						</li>
 						<li>
@@ -419,7 +419,7 @@
 					<h2>Tecnologías actuales</h2>
 					<h3>(Desde el 2000)</h3>
 					<ul>
-						<li>Correción transparente de errores.</li>
+						<li>Corrección transparente de errores.</li>
 						<li>Manejo directo de dispositivos.</li>
 						<li>Árboles estructurados de registros.</li>
 						<li>Árboles balanceados de referencias de copy-write.</li>
@@ -514,13 +514,13 @@
 						<li>
 							Bloques de tamaño grande crean gran desperdicio de
 							espacio en archivos pequeños, pero hace la búsqueda
-							mas rápida.
+							más rápida.
 						</li>
 						<li>
 							Bloque de tamaño pequeño minimizan el desperdicio de
 							espacio pero ralentizan significativamente la lectura de
 							archivos, puesto que deben recorrer varios bloques para
-							tener acceso a el. 
+							tener acceso a él.
 						</li>
 					</ul>
 				</section>
@@ -558,7 +558,7 @@
 					<ul>
 						<li> 
 							Los respaldos pueden ser definidos en esquemas 
-							completas, incrementales o diferenciales.
+							completos, incrementales o diferenciales.
 						</li>
 						<li>
 							Se debe tener en cuenta permisos de usuario, cuotas de
@@ -577,7 +577,7 @@
 							los cambios, puede crearse una inconsistencia.
 						</li>
 						<li>
-							Se puede tornar mas crítico sin las inconsistencias se
+							Se puede tornar más crítico sin las inconsistencias se
 							presentas en bloques con nodos-i, directorios o la lista
 							de bloques libres.
 						</li>
@@ -611,7 +611,7 @@
 					<h2>Rendimiento del S.A.</h2>
 					<ul>
 						<li>
-							El disco duro es el dispositivo mas lento del sistema, en
+							El disco duro es el dispositivo más lento del sistema, en
 							comparación con el CPU o la memoria principal.
 						</li>
 						<li>
@@ -636,7 +636,7 @@
 							frecuentemente en un espacio de memoria principal.
 						</li>
 						<li>
-							El reemplazo de los bloques en cache se hacen utilizando los
+							El reemplazo de los bloques en caché se hacen utilizando los
 							métodos de FIFO, segunda oportunidad y LRU.
 						</li>
 						<li>

--- a/12-Discos.html
+++ b/12-Discos.html
@@ -89,11 +89,11 @@
 						<li>Almacenamiento no volátil.</li>
 						<li>Alta velocidad de acceso.</li>
 						<li>Susceptibles de ser soporte para el sistema de archivos.</li>
-						<li>Suele ser mas económicos que otros tipos de memoria.</li>
+						<li>Suele ser más económicos que otros tipos de memoria.</li>
 					</ul>
 					<aside class="notes">
-						Preguntar cuales son, como por ejemplo: Magnéticos como 
-						disco duros, cintas, diskette. Ópticos como CD, DVD, Blu-Ray.
+						Preguntar cuáles son, como por ejemplo: Magnéticos como
+						discos duros, cintas, diskette. Ópticos como CD, DVD, Blu-Ray.
 						Sólido como memorias flash, SSD. Híbridos como SSD y HD.
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 						</aside>
 					</p>
 					<aside class="notes">
-						Solo la RAM es mas rápida
+						Solo la RAM es más rápida
 					</aside>
 				</section>
 
@@ -154,7 +154,7 @@
 				<section id="estructura-disco">
 					<h2>Estructura de un disco duro</h2>
 					<p>
-						Los DD están compuesto por varias superficies magnetizadas y cabezas
+						Los DD están compuestos por varias superficies magnetizadas y cabezas
 						lectoras/escritoras por efecto electromagnético. Las superficies se 
 						dividen en <strong>cilindros</strong>, con una <strong>pista</strong>
 						para cada cabeza y un cierto número de <strong>sectores</strong> por pista.
@@ -189,7 +189,7 @@
 
 						<li>
 							Los SSD escriben la información en bloques, por lo tanto,
-							no se organizan de la misma forma que los disco duros mecánicos.
+							no se organizan de la misma forma que los discos duros mecánicos.
 						</li>
 					</ul>
 				</section>
@@ -304,7 +304,7 @@
 					<aside class="notes">
 						El ancho de banda del disco es el número total de bytes transferidos,
 						divididos por el tiempo total entre la primera solicitud de servicio y el
-						termino de la última transferencia.
+						término de la última transferencia.
 					</aside>
 				</section>
 
@@ -352,8 +352,8 @@
 				<section id="SSTF">
 					<h2>Shortest Seek Time First (SSTF) </h2>
 					<p>
-						Accede a las peticiones mas cercanas de la posición actual, pero
-						existe riesgo de nunca atender a las mas lejanas debido a nuevas
+						Accede a las peticiones más cercanas de la posición actual, pero
+						existe riesgo de nunca atender a las más lejanas debido a nuevas
 						peticiones cercanas (hambruna). Este algoritmo es una modificación
 						de SJF.
 					</p>

--- a/13-EntradaSalida.html
+++ b/13-EntradaSalida.html
@@ -82,7 +82,7 @@
 						<h2>Dispositivos de E/S</h2>
 						<p>
 							Los sistemas operativos se esfuerzan para optimizar la E/S.
-							Debido a que son los mas lentos de todo el sistema, por ejemplo:
+							Debido a que son los más lentos de todo el sistema, por ejemplo:
 							<ul>
 								<li>CPU ejecuta operaciones a 1-4 GHz aproximadamente.</li>
 								<li>El acceso a RAM es de nanosegundos.</li>
@@ -111,7 +111,7 @@
 
 				<section id="caracterizacion-es">
 					<h2>Caracterización de los Dispositivos de E/S</h2>
-					<h3>¿Cómo se ven los dispositivo de E/S?</h3>
+					<h3>¿Cómo se ven los dispositivos de E/S?</h3>
 					<ul>
 						<li>
 							<strong>Los programadores:</strong> una caja negra que permite leer y 
@@ -267,7 +267,7 @@
 							</ul>
 							<h4>Dispositivos de bloque</h4>
 							<ul>
-								<li>Accesso por bloques de datos, utilizan búffers.</li>
+								<li>Acceso por bloques de datos, utilizan búffers.</li>
 								<li>El disco duro funciona de esta manera.</li>
 							</ul>
 						</li>

--- a/14-Seguridad.html
+++ b/14-Seguridad.html
@@ -181,7 +181,7 @@
 					<h3>Integridad de los datos</h3>
 					<ul>
 						<li>
-							Lo usuarios no autorizados no deben ser capaces de modificar
+							Los usuarios no autorizados no deben ser capaces de modificar
 							datos sin el permiso del propietario. 
 						</li>
 						<li>
@@ -215,7 +215,7 @@
 					<ul>
 						<li>Proteger a los individuos sobre el mal uso de la información sobre ellos.</li>
 						<li>Existen marcos legales que permiten acceder a información privada de los usuarios.</li>
-					 	<li>¿Hasta donde llega la privacidad entonces?</li>
+					 	<li>¿Hasta dónde llega la privacidad entonces?</li>
 					</ul>
 				</section>
 	
@@ -456,7 +456,7 @@
 						</li>
 						<li>
 							Una vez recibido el mensaje, se calcula
-							nuevamente su numero hash, se descifra el que
+							nuevamente su número hash, se descifra el que
 							viene junto con el documento y se procede a
 							compararlo.
 						</li>
@@ -604,7 +604,7 @@
 					<div class="half left">
 						<ul>
 							<li>
-								Es de las matriz de control sin espacios vacíos 
+								Es de la matriz de control sin espacios vacíos
 								al ser implementado en una lista dinámica 
 								como estructura de datos.
 							</li>
@@ -659,9 +659,9 @@
 					</div>
 					<ul>
 						<li>
-							De ésta manera, la búsqueda es mas rápida al momento
+							De ésta manera, la búsqueda es más rápida al momento
 							de consultar la información de un objeto, pues la información
-							esta ordenada por objetos.
+							está ordenada por objetos.
 						</li>
 					</ul>
 				</section>
@@ -709,7 +709,7 @@
 							Todos los sistemas computacionales seguros
 							deberían solicitar que los usuarios se
 							autentiquen de tal forma de identificar quien
-							esta haciendo uso de los sus recursos.
+							está haciendo uso de los sus recursos.
 						</li>
 					</ul>
 				</section>
@@ -792,7 +792,7 @@
 					<aside class="notes">
 						El tipo de información y la manera de procesarla
 						depende del dispositivo y el sistema informático en
-						el que se este identificando.
+						el que se esté identificando.
 					</aside>
 				</section>
 
@@ -831,7 +831,7 @@
 							recursos que se desean proteger.
 						</li>	
 						<li>
-							Controles mas elaborados requieren mayor
+							Controles más elaborados requieren mayor
 							esfuerzo administrativo, así como también
 							tienen mayores costos de implementación.
 						</li>
@@ -967,7 +967,7 @@
 					<ul>
 						<li>
 							Se vale de la falta de validación en los límites de
-							memoria utilizado por los compiladores,
+							memoria utilizada por los compiladores,
 							generalmente de C.
 						</li>
 						<li>
@@ -976,7 +976,7 @@
 							programa.
 						</li>
 						<li>
-							Podría incluirse rutinas especificas para realizar
+							Podría incluirse rutinas específicas para realizar
 							acciones particulares en el sistema.
 						</li>
 					</ul>
@@ -1012,7 +1012,7 @@
 							Consiste en aprovecharse de las funciones de una
 							biblioteca compartida para introducir y ejecutar
 							código malicioso en memoria, en vez de
-							proporcionar los datos para los cuales esta
+							proporcionar los datos para los cuales está
 							diseñada la entrada del programa.
 						<li>
 							Esto permite que usuarios maliciosos puedan
@@ -1025,7 +1025,7 @@
 
 				<section id="desbordamiento-enteros">
 					<h2>Explotar errores de código</h2>
-					<h3>Ataques por desboradmiento de enteros</h3>
+					<h3>Ataques por desbordamiento de enteros</h3>
 					<div class="half left">
 						<ul>
 							<li>
@@ -1065,7 +1065,7 @@
 					<ul>
 						<li>
 							Tiene como objeto engañar al sistema para que le
-							proporcione mas permisos de los que un usuario
+							proporcione más permisos de los que un usuario
 							debería tener, con el fin de acceder a otras partes
 							del sistema y obtener información sensible o
 							modificar datos del sistema.
@@ -1086,7 +1086,7 @@
 								entre otros.
 							</li>
 							<li>
-								Entre los mas conocidos tenemos:
+								Entre los más conocidos tenemos:
 							 	Netbus, Sub7, Back Orifice, etc.
 							</li>
 						</ul>
@@ -1201,7 +1201,7 @@
 						<img src="img/class14/rootkit.gif" alt="Rootkit" />
 					</div>
 					<aside class="notes">
-						Uno de los casos mas conocido fue el rootkit incluído
+						Uno de los casos más conocido fue el rootkit incluído
 						en los CDs de música de SONY.
 					</aside>
 				</section>


### PR DESCRIPTION
This pull request focuses on correcting typographical and grammatical errors across multiple HTML files in the project. The changes enhance readability ensuring grammatical accuracy.

### Examples Typographical and Grammatical  Corrections:
* Corrected the spelling of "esta" to "está" to properly use the accent in `01-Introduccion.html` (`<h2>Arquitectura Von Neuman</h2>`).
* Fixed "mas" to "más" to correctly apply the accent for "más" (e.g., "más conocidos," "más óptima") in multiple sections of `01-Introduccion.html`. [[1]](diffhunk://#diff-b06f9f6805e6f159e5bfb4ccbe8fe849f1a0eb810b1600becfe6d8b18e836b58L260-R260) [[2]](diffhunk://#diff-b06f9f6805e6f159e5bfb4ccbe8fe849f1a0eb810b1600becfe6d8b18e836b58L435-R435) [[3]](diffhunk://#diff-b06f9f6805e6f159e5bfb4ccbe8fe849f1a0eb810b1600becfe6d8b18e836b58L451-R451) [[4]](diffhunk://#diff-b06f9f6805e6f159e5bfb4ccbe8fe849f1a0eb810b1600becfe6d8b18e836b58L480-R480)
* Replaced  "comparter" with "comparten" in `05-SincronizacionProcesos.html` 
* Replaced "cuelge" with "cuelgue" in `05-SincronizacionProcesos.html` 
* Replaced "calculo" to "cálculo" in `01-Introduccion.html`


### Example Consistency and Readability:
* Replaced "separados" with "separadas" in `03-Hilos.html` to maintain grammatical agreement.
* Adjusted "va consumir" to "va a consumir" in `05-SincronizacionProcesos.html` for grammatical accuracy.

**This is just a few examples**